### PR TITLE
use jasmine-node for 1.3 tests, create tests for 2.x and 1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,14 @@
     "url": "git@github.com:jeffmo/jasmine-pit.git"
   },
   "scripts": {
-    "test": "jasmine"
+    "test": "jasmine",
+    "test-legacy": "jasmine-node . --verbose"
   },
   "license": "MIT",
   "devDependencies": {
-    "jasmine": "^2.2.1"
+    "q": "^1.2.0",
+    "jasmine": "^2.2.1",
+    "jasmine-only": "^0.1.0",
+    "jasmine-node": "^1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "test": "jasmine",
-    "test-legacy": "jasmine-node . --verbose"
+    "test-legacy": "jasmine-node ."
   },
   "license": "MIT",
   "devDependencies": {

--- a/spec/jasmine-pit-spec.js
+++ b/spec/jasmine-pit-spec.js
@@ -1,20 +1,59 @@
 /* global pit */
 
 var jasminePit = require('../index');
+var Q = require('q');
 
 jasminePit.install(global);
 
 describe('JasminePit: ', function () {
+
   it('should have `pit`, `xpit` on globalObject', function () {
     expect(global.pit).toBeDefined();
     expect(global.xpit).toBeDefined();
   });
 
-  describe('Jasmine 1.x specific', function () {});
+  var trueFn = function() { return true; }
+  var promiseTrue = function() { return Q.fcall(trueFn); }
 
-  describe('Jasmine 2.x specific', function () {
-    it('should have `fpit` on globalObject', function () {
-      expect(global.fpit).toBeDefined();
+  pit('promised true is true', function() {
+
+    return promiseTrue().then(function(result) {
+      expect(result).toBe(true);
     });
+
   });
+
+  xpit('xpit should be ignored', function() {
+
+    // test will not show as 'pending' in Jasmine 1.x results
+    return promiseTrue().then(function(result) {
+      expect(result).toBe(false);
+    });
+
+  });
+
+  var isLegacyJasmine = jasmine.version_ && jasmine.version_.major === 1;
+
+  if (isLegacyJasmine) {
+
+    describe('Jasmine 1.x specific', function () {
+
+      it('should have pit.only defined', function() {
+        expect(global.pit.only).toBeDefined();
+      });
+
+    });
+
+  } else {
+
+    describe('Jasmine 2.x specific', function () {
+
+      it('should have `fpit` on globalObject', function () {
+        expect(global.fpit).toBeDefined();
+      });
+
+    });
+
+  }
+
 });


### PR DESCRIPTION
Here are some tests and required package.json changes. 
`npm run test-legacy` to run jasmine 1.3 tests.
No browser tests done.
